### PR TITLE
Extend job to upload schema artifact to release

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,0 +1,44 @@
+name: Generate OpenAPI
+on:
+  release:
+    types: [published]
+
+jobs:
+  openapi:
+    runs-on: ubuntu-latest
+    env:
+      DEBUG: True
+      SECRET_KEY: changeme!
+      ALLOWED_HOSTS: localhost,127.0.0.1
+      DATABASE_URL: sqlite:////tmp/db.sqlite3
+      CORS_ORIGIN_WHITELIST: "http://localhost,http://127.0.0.1"
+      REGISTER_VERIFICATION_URL: "http://localhost:4200/verify-user/"
+      RESET_PASSWORD_VERIFICATION_URL: "http://localhost:4200/reset-password/"
+      REGISTER_EMAIL_VERIFICATION_URL: "http://localhost:4200/verify-email/"
+
+    strategy:
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Generate OpenAPI
+      run: python manage.py spectacular --file schema.yml
+      working-directory: snypy
+
+    - name: Upload to release
+      uses: JasonEtco/upload-to-release@master
+      with:
+        args: ./snypy/schema.yml text/yaml
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a workflow that generates and upload the openapi.yml file to a new release after it is published.

Fixes https://github.com/snypy/snypy-backend/issues/77