### PR TITLE
Add properties for permissions on snippet of current user, fixes editable permission

### DIFF
--- a/snypy/core/models/models.py
+++ b/snypy/core/models/models.py
@@ -5,6 +5,14 @@ class BaseModel(models.Model):
     class Meta:
         abstract = True
 
+    @property
+    def editable(self):
+        return self.__class__.objects.filter(pk=self.pk).editable().exists()
+
+    @property
+    def deletable(self):
+        return self.__class__.objects.filter(pk=self.pk).deletable().exists()
+
 
 class DateModelMixin(models.Model):
     created_date = models.DateTimeField(auto_now_add=True)

--- a/snypy/snippets/rest/serializers.py
+++ b/snypy/snippets/rest/serializers.py
@@ -46,6 +46,8 @@ class SnippetSerializer(BaseSerializer):
             "labels",
             "files",
             "team",
+            "editable",
+            "deletable",
         )
 
     def get_user_display(self, obj):


### PR DESCRIPTION
Provides new properties that can be set on a model serializer for editable or deletable checks.