### PR TITLE
Fix workflow for generating openapi spec

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DEBUG: True
-      RUN_MODE: test
+      RUN_MODE: production
       SECRET_KEY: changeme!
       ALLOWED_HOSTS: localhost,127.0.0.1
       DATABASE_URL: sqlite:////tmp/db.sqlite3
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Use run mode `production`, as currently only the base dependencies are installed.
