### PR TITLE
Extend workflow to publish angular client on release

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -44,3 +44,39 @@ jobs:
         args: ./snypy/schema.yml text/yaml
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Get release version
+      id: get_version
+      run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Verify Docker installation
+      run: |
+        docker --version
+        docker pull openapitools/openapi-generator-cli
+
+    - name: Generate TypeScript Client
+      run: |
+        docker run -u $(id -u):$(id -g) --rm -v "${PWD}:/local" openapitools/openapi-generator-cli generate \
+          -i https://github.com/snypy/snypy-backend/releases/download/${{ steps.get_version.outputs.VERSION }}/schema.yml \
+          -g typescript-angular \
+          -o /local/client \
+          --additional-properties=npmName=@snypy/rest-client,npmVersion=${{ steps.get_version.outputs.VERSION }},useSingleRequestParameter=true
+
+    - name: Build TypeScript Client
+      run: |
+        cd client
+        npm install --force
+        npm run build
+
+    - name: Publish to NPM
+      run: |
+        cd client/dist
+        npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request adds several steps to the GitHub Actions workflow for generating, building, and publishing a TypeScript client using the OpenAPI Generator.